### PR TITLE
Feature material card

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
@@ -1,0 +1,85 @@
+package org.phoenixframework.liveview.data.dto
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
+
+class CardDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
+    var shape: Shape = builder.shape
+    var backgroundColor: Color = builder.backgroundColor
+    var elevation: Dp = builder.elevation
+
+    @Composable
+    fun Compose(content: @Composable () -> Unit) {
+        Card(
+            modifier = modifier,
+            backgroundColor = backgroundColor,
+            elevation = elevation,
+            shape = shape,
+        ) {
+            content()
+        }
+    }
+
+    class Builder : ComposableBuilder() {
+        var shape: Shape = RoundedCornerShape(0.dp)
+        var backgroundColor: Color = Color.White
+        var elevation: Dp = 1.dp
+
+        fun shape(shape: String) = apply {
+            this.shape = when {
+                shape.isNotEmptyAndIsDigitsOnly() -> RoundedCornerShape(shape.toInt().dp)
+                shape.isNotEmpty() && shape == "circle" -> CircleShape
+                shape.isNotEmpty() && shape == "rectangle" -> RectangleShape
+                else -> RoundedCornerShape(0.dp)
+            }
+        }
+
+        fun backgroundColor(color: String) = apply {
+            if (color.isNotEmpty()) {
+                this.backgroundColor = Color(java.lang.Long.decode(color))
+            }
+        }
+
+        fun elevation(elevation: String) = apply {
+            if (elevation.isNotEmptyAndIsDigitsOnly()) {
+                this.elevation = (elevation.toInt()).dp
+            }
+        }
+
+        override fun size(size: String): Builder = apply {
+            super.size(size)
+        }
+
+        override fun padding(padding: String): Builder = apply {
+            super.padding(padding)
+        }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply {
+            super.height(height)
+        }
+
+        override fun width(width: String): Builder = apply {
+            super.width(width)
+        }
+
+        fun build() = CardDTO(this)
+    }
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
@@ -2,5 +2,6 @@ package org.phoenixframework.liveview.domain.base
 
 object ComposableTypes {
     const val asyncImage = "async-image"
+    const val card = "card"
     const val text = "text"
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -3,6 +3,7 @@ package org.phoenixframework.liveview.domain.factory
 import org.jsoup.nodes.Attributes
 import org.jsoup.nodes.Element
 import org.phoenixframework.liveview.data.dto.AsyncImageDTO
+import org.phoenixframework.liveview.data.dto.CardDTO
 import org.phoenixframework.liveview.data.dto.TextDTO
 import org.phoenixframework.liveview.domain.base.ComposableTypes
 import org.phoenixframework.liveview.domain.base.ComposableView
@@ -20,6 +21,11 @@ object ComposableNodeFactory {
      * @return a `ComposableTreeNode` object based on the input `Element` object
      */
     fun buildComposable(element: Element): ComposableTreeNode = when (element.tagName()) {
+        ComposableTypes.card -> {
+            ComposableTreeNode(
+                buildCardNode(attributes = element.attributes())
+            )
+        }
         ComposableTypes.text -> {
             ComposableTreeNode(
                 buildTextNode(attributes = element.attributes(), text = element.text())
@@ -51,6 +57,27 @@ object ComposableNodeFactory {
                     "content-description" -> builder.contentDescription(attribute.key)
                     "cross-fade" -> builder.crossFade(attribute.key)
                     "shape" -> builder.shape(attribute.key)
+                    "size" -> builder.size(attribute.value)
+                    "height" -> builder.height(attribute.value)
+                    "width" -> builder.width(attribute.value)
+                    else -> builder
+                }
+            }
+            .build()
+
+    /**
+     * Creates a `CardDTO` object based on the attributes of the input `Attributes` object.
+     * Card co-relates to the Card composable
+     * @param attributes the `Attributes` object to create the `CardDTO` object from
+     * @return a `CardDTO` object based on the attributes of the input `Attributes` object
+     **/
+    private fun buildCardNode(attributes: Attributes): ComposableView =
+        attributes
+            .fold(CardDTO.Builder()) { builder, attribute ->
+                when (attribute.key) {
+                    "shape" -> builder.shape(attribute.value)
+                    "background-color" -> builder.backgroundColor(attribute.value)
+                    "elevation" -> builder.elevation(attribute.value)
                     "size" -> builder.size(attribute.value)
                     "height" -> builder.height(attribute.value)
                     "width" -> builder.width(attribute.value)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
@@ -3,7 +3,7 @@ package org.phoenixframework.liveview.domain.factory
 import org.phoenixframework.liveview.domain.base.ComposableView
 
 class ComposableTreeNode(val value: ComposableView) {
-    private val children: MutableList<ComposableTreeNode> = mutableListOf()
+    val children: MutableList<ComposableTreeNode> = mutableListOf()
 
     fun addNode(child: ComposableTreeNode) {
         children.add(child)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -17,6 +17,13 @@ private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
         is AsyncImageDTO -> {
             composableTreeNode.value.Compose()
         }
+        is CardDTO -> {
+            composableTreeNode.value.Compose {
+                composableTreeNode.children.forEach { node ->
+                    TraverseComposableViewTree(composableTreeNode = node)
+                }
+            }
+        }
         is TextDTO -> {
             composableTreeNode.value.Compose()
         }


### PR DESCRIPTION
Closes #22 

This adds support for layout container Card. 

```html
 <card elevation="2" shape="8" width="fill" height ="350" background-color = "0xFFF2F2F2"  padding = "18" >
   <async-image content-scale="fit"  width="150" height="150" padding="24" url= "https://www.themoviedb.org/t/p/w1280/94xxm5701CzOdJdUEdIuwqZaowx.jpg"/>
 </card>
 ``` 
 
![Screenshot 2023-01-31 at 3 18 22 PM](https://user-images.githubusercontent.com/61690178/215732935-405b1d02-b34a-4dd3-bc48-4faa542a58cb.png)

Attribute list:

 "shape"
 "background-color" 
 "elevation" 
  "size"
  "height" 
  "width"
  "padding"
  "horizontal-padding" 
  "vertical-padding" 
         
