### PR TITLE
Feature lazy column

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
@@ -1,0 +1,134 @@
+package org.phoenixframework.liveview.data.dto
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
+import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
+
+class LazyColumnDTO private constructor(builder: Builder) :
+    ComposableView(modifier = builder.modifier) {
+    private val verticalArrangement: Arrangement.Vertical = builder.verticalArrangement
+    private val horizontalAlignment: Alignment.Horizontal = builder.horizontalAlignment
+
+    // content padding is a pair of pairs,
+    // the first pair is the horizontal padding,
+    // the second pair is the vertical padding
+    private var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = builder.contentPadding
+
+    @Composable
+    fun ComposeLazyItems(
+        items: MutableList<ComposableTreeNode>,
+        drawContent: @Composable (node: ComposableTreeNode) -> Unit
+    ) {
+        LazyColumn(
+            modifier = modifier,
+            verticalArrangement = verticalArrangement,
+            horizontalAlignment = horizontalAlignment,
+            contentPadding =
+                PaddingValues(
+                    contentPadding.first.first.dp,
+                    contentPadding.second.first.dp,
+                    contentPadding.first.second.dp,
+                    contentPadding.second.second.dp),
+            content = { items(items, key = { item -> item.id }) { item -> drawContent(item) } })
+    }
+
+    class Builder : ComposableBuilder() {
+        var verticalArrangement: Arrangement.Vertical = Arrangement.Top
+        var horizontalAlignment: Alignment.Horizontal = Alignment.Start
+        var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = Pair(Pair(0, 0), Pair(0, 0))
+
+        fun verticalArrangement(verticalArrangement: String) = apply {
+            this.verticalArrangement =
+                when (verticalArrangement) {
+                    "top" -> Arrangement.Top
+                    "space-evenly" -> Arrangement.SpaceEvenly
+                    "space-around" -> Arrangement.SpaceAround
+                    "space-between" -> Arrangement.SpaceBetween
+                    "bottom" -> Arrangement.Bottom
+                    "center" -> Arrangement.Center
+                    else -> Arrangement.spacedBy(verticalArrangement.toInt().dp)
+                }
+        }
+
+        fun horizontalAlignment(horizontalAlignment: String) = apply {
+            this.horizontalAlignment =
+                when (horizontalAlignment) {
+                    "start" -> Alignment.Start
+                    "center" -> Alignment.CenterHorizontally
+                    "end" -> Alignment.End
+                    else -> Alignment.Start
+                }
+        }
+
+        fun rightPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding =
+                    Pair(
+                        Pair(contentPadding.first.first, paddingValue.toInt()),
+                        Pair(contentPadding.second.first, contentPadding.second.second))
+            }
+        }
+
+        fun leftPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding =
+                    Pair(
+                        Pair(paddingValue.toInt(), contentPadding.first.second),
+                        Pair(contentPadding.second.first, contentPadding.second.second))
+            }
+        }
+
+        fun topPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding =
+                    Pair(
+                        Pair(contentPadding.first.first, contentPadding.first.second),
+                        Pair(paddingValue.toInt(), contentPadding.second.second))
+            }
+        }
+
+        fun bottomPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding =
+                    Pair(
+                        Pair(contentPadding.first.first, contentPadding.first.second),
+                        Pair(contentPadding.second.first, paddingValue.toInt()))
+            }
+        }
+
+        fun lazyColumnItemPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding =
+                    Pair(
+                        Pair(paddingValue.toInt(), paddingValue.toInt()),
+                        Pair(paddingValue.toInt(), paddingValue.toInt()))
+            }
+        }
+
+        override fun size(size: String): Builder = apply { super.size(size) }
+
+        override fun padding(padding: String): Builder = apply { super.padding(padding) }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply { super.height(height) }
+
+        override fun width(width: String): Builder = apply { super.width(width) }
+
+        fun build() = LazyColumnDTO(this)
+    }
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
@@ -4,6 +4,7 @@ object ComposableTypes {
     const val asyncImage = "async-image"
     const val card = "card"
     const val column = "column"
+    const val lazyColumn = "lazy-column"
     const val row = "row"
     const val text = "text"
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -22,6 +22,9 @@ object ComposableNodeFactory {
         ComposableTypes.asyncImage -> ComposableTreeNode(buildAsyncImageNode(element.attributes()))
         ComposableTypes.card -> ComposableTreeNode(buildCardNode(element.attributes()))
         ComposableTypes.column -> ComposableTreeNode(buildColumnNode(element.attributes()))
+        ComposableTypes.lazyColumn -> ComposableTreeNode(
+            buildLazyColumnNode(attributes = element.attributes())
+        )
         ComposableTypes.row -> ComposableTreeNode(buildRowNode(element.attributes()))
         ComposableTypes.text -> ComposableTreeNode(
             buildTextNode(attributes = element.attributes(), text = element.text())
@@ -105,6 +108,31 @@ object ComposableNodeFactory {
                     "padding" -> builder.padding(attribute.value)
                     "horizontal-padding" -> builder.horizontalPadding(attribute.value)
                     "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    else -> builder
+                }
+            }
+            .build()
+
+    private fun buildLazyColumnNode(attributes: Attributes): ComposableView =
+        attributes
+            .fold(LazyColumnDTO.Builder()) { builder, attribute ->
+                when (attribute.key) {
+                    "height" -> builder.height(attribute.value)
+                    "horizontal-alignment" -> builder.horizontalAlignment(attribute.value)
+                    "horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "item-bottom-padding" -> builder.bottomPadding(attribute.value)
+                    "item-horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "item-left-padding" -> builder.leftPadding(attribute.value)
+                    "item-padding" -> builder.lazyColumnItemPadding(attribute.value)
+                    "item-right-padding" -> builder.rightPadding(attribute.value)
+                    "item-top-padding" -> builder.topPadding(attribute.value)
+                    "item-vertical-padding" -> builder.verticalPadding(attribute.value)
+                    "padding" -> builder.padding(attribute.value)
+                    "reverse-layout" -> builder.horizontalAlignment(attribute.value)
+                    "size" -> builder.size(attribute.value)
+                    "vertical-arrangement" -> builder.verticalArrangement(attribute.value)
+                    "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    "width" -> builder.width(attribute.value)
                     else -> builder
                 }
             }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
@@ -1,8 +1,10 @@
 package org.phoenixframework.liveview.domain.factory
 
 import org.phoenixframework.liveview.domain.base.ComposableView
+import java.util.*
 
 class ComposableTreeNode(val value: ComposableView) {
+    val id = UUID.randomUUID().toString()
     val children: MutableList<ComposableTreeNode> = mutableListOf()
 
     fun addNode(child: ComposableTreeNode) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -6,40 +6,32 @@ import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 
 @Composable
 fun PhxLiveView(liveViewState: MutableList<ComposableTreeNode>) {
-    liveViewState.forEach { node ->
-        TraverseComposableViewTree(composableTreeNode = node)
-    }
+    liveViewState.forEach { node -> TraverseComposableViewTree(composableTreeNode = node) }
 }
 
 @Composable
 private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
     when (composableTreeNode.value) {
-        is AsyncImageDTO -> {
-            composableTreeNode.value.Compose()
-        }
-        is CardDTO -> {
-            composableTreeNode.value.Compose {
-                composableTreeNode.children.forEach { node ->
-                    TraverseComposableViewTree(composableTreeNode = node)
-                }
+        is AsyncImageDTO -> composableTreeNode.value.Compose()
+        is CardDTO -> composableTreeNode.value.Compose {
+            composableTreeNode.children.forEach { node ->
+                TraverseComposableViewTree(composableTreeNode = node)
             }
         }
-        is ColumnDTO -> {
-            composableTreeNode.value.Compose {
-                composableTreeNode.children.forEach {node->
-                    TraverseComposableViewTree(composableTreeNode = node)
-                }
+        is ColumnDTO -> composableTreeNode.value.Compose {
+            composableTreeNode.children.forEach { node ->
+                TraverseComposableViewTree(composableTreeNode = node)
             }
         }
-        is RowDTO -> {
-            composableTreeNode.value.Compose {
-                composableTreeNode.children.forEach {node->
-                    TraverseComposableViewTree(composableTreeNode = node)
-                }
+        is LazyColumnDTO ->
+            composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
+                TraverseComposableViewTree(composableTreeNode = node)
+            }
+        is RowDTO -> composableTreeNode.value.Compose {
+            composableTreeNode.children.forEach { node ->
+                TraverseComposableViewTree(composableTreeNode = node)
             }
         }
-        is TextDTO -> {
-            composableTreeNode.value.Compose()
-        }
+        is TextDTO -> composableTreeNode.value.Compose()
     }
 }


### PR DESCRIPTION
Closes #14 

This adds support for lazy column. Lazy column is an extension of column and loads element in a vertical fashion, however, unlike column it can lazy load items and reuse previously rendered views.

each element can be segregated using the item tag

```html
<item> text </item>
```
Template

```html
   <lazy-column vertical-arrangement= "16" horizontal-alignment="center" height="fill" width = "fill" item-padding = "16">
      <item>
         <card elevation="2" shape="8" width="fill" height ="350" background-color = "0xFFF2F2F2" >
            <column vertical-arrangement="space-evenly" horizontal-alignment="start" size="fill" padding = "12" >
               <async-image width="fill" height="150" content-scale="fit" shape="18"> https://m.media-amazon.com/images/M/MV5BZDY0Mjg1OTEtMDEyNS00OWM0LTg0YTYtNjA3YzY2NGRjYWJiXkEyXkFqcGdeQXVyODk4OTc3MTY@._V1_FMjpg_UX1000_.jpg </async-image>
               <text color="0xFF000000" font-size="24" font-weight="W800"> Ant Man and The Wasp: Quantamania </text>
               <text color="0xFF000000" font-size="14" max-lines="4" overflow="ellipsis">Ant-Man and the Wasp find themselves exploring the Quantum Realm, interacting with strange new creatures and embarking on an adventure that pushes them beyond the limits of what they thought was possible.</text>
               <row horizontal-arrangement="space-between" vertical-alignment="center">
                  <text color="0xFFF4B400" font-size="12"> Audience rating 94%</text>
                  <text color="0xFFF4B400" font-size="12"> Roton tomatoes rating 64%</text>
               </row>
            </column>
         </card>
      </item>
      
   </lazy-column>
  ```
[lazycolumn.webm](https://user-images.githubusercontent.com/61690178/215747274-233e3623-9154-46ae-8ef6-c472952db3ad.webm)

Attribute list:

   "item-left-padding" 
   "item-right-padding"
   "item-top-padding" 
  "item-bottom-padding" 
  "item-horizontal-padding" 
  "item-vertical-padding" 
  "item-padding"
   "padding"
   "reverse-layout"
   "vertical-arrangement" 
   "height"
    "width" 
    "horizontal-alignment" 
    "size" 
    "horizontal-padding" 
   "vertical-padding" 


Documentation Link: 
https://developer.android.com/jetpack/compose/lists

