### PR TITLE
Feature lazy row

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
@@ -20,7 +20,9 @@ class LazyColumnDTO private constructor(builder: Builder) :
     // content padding is a pair of pairs,
     // the first pair is the horizontal padding,
     // the second pair is the vertical padding
-    private var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = builder.contentPadding
+    private val contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = builder.contentPadding
+
+    private val reverseLayout: Boolean = builder.reverseLayout
 
     @Composable
     fun ComposeLazyItems(
@@ -29,21 +31,31 @@ class LazyColumnDTO private constructor(builder: Builder) :
     ) {
         LazyColumn(
             modifier = modifier,
+            reverseLayout = reverseLayout,
             verticalArrangement = verticalArrangement,
             horizontalAlignment = horizontalAlignment,
             contentPadding =
-                PaddingValues(
-                    contentPadding.first.first.dp,
-                    contentPadding.second.first.dp,
-                    contentPadding.first.second.dp,
-                    contentPadding.second.second.dp),
-            content = { items(items, key = { item -> item.id }) { item -> drawContent(item) } })
+            PaddingValues(
+                contentPadding.first.first.dp,
+                contentPadding.second.first.dp,
+                contentPadding.first.second.dp,
+                contentPadding.second.second.dp
+            ),
+            content = { items(items, key = { item -> item.id }) { item -> drawContent(item) } }
+        )
     }
 
     class Builder : ComposableBuilder() {
         var verticalArrangement: Arrangement.Vertical = Arrangement.Top
         var horizontalAlignment: Alignment.Horizontal = Alignment.Start
         var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = Pair(Pair(0, 0), Pair(0, 0))
+        var reverseLayout: Boolean = false
+
+        fun reverseLayout(isReverseLayout: String) = apply {
+            if (isReverseLayout.isNotEmpty()) {
+                this.reverseLayout = isReverseLayout.toBoolean()
+            }
+        }
 
         fun verticalArrangement(verticalArrangement: String) = apply {
             this.verticalArrangement =
@@ -73,7 +85,8 @@ class LazyColumnDTO private constructor(builder: Builder) :
                 contentPadding =
                     Pair(
                         Pair(contentPadding.first.first, paddingValue.toInt()),
-                        Pair(contentPadding.second.first, contentPadding.second.second))
+                        Pair(contentPadding.second.first, contentPadding.second.second)
+                    )
             }
         }
 
@@ -82,7 +95,8 @@ class LazyColumnDTO private constructor(builder: Builder) :
                 contentPadding =
                     Pair(
                         Pair(paddingValue.toInt(), contentPadding.first.second),
-                        Pair(contentPadding.second.first, contentPadding.second.second))
+                        Pair(contentPadding.second.first, contentPadding.second.second)
+                    )
             }
         }
 
@@ -91,7 +105,8 @@ class LazyColumnDTO private constructor(builder: Builder) :
                 contentPadding =
                     Pair(
                         Pair(contentPadding.first.first, contentPadding.first.second),
-                        Pair(paddingValue.toInt(), contentPadding.second.second))
+                        Pair(paddingValue.toInt(), contentPadding.second.second)
+                    )
             }
         }
 
@@ -100,7 +115,8 @@ class LazyColumnDTO private constructor(builder: Builder) :
                 contentPadding =
                     Pair(
                         Pair(contentPadding.first.first, contentPadding.first.second),
-                        Pair(contentPadding.second.first, paddingValue.toInt()))
+                        Pair(contentPadding.second.first, paddingValue.toInt())
+                    )
             }
         }
 
@@ -109,7 +125,8 @@ class LazyColumnDTO private constructor(builder: Builder) :
                 contentPadding =
                     Pair(
                         Pair(paddingValue.toInt(), paddingValue.toInt()),
-                        Pair(paddingValue.toInt(), paddingValue.toInt()))
+                        Pair(paddingValue.toInt(), paddingValue.toInt())
+                    )
             }
         }
 

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
@@ -1,0 +1,151 @@
+package org.phoenixframework.liveview.data.dto
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
+import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
+
+class LazyRowDTO private constructor(builder: Builder) :
+    ComposableView(modifier = builder.modifier) {
+    private var horizontalArrangement: Arrangement.Horizontal = builder.horizontalArrangement
+    private var verticalAlignment: Alignment.Vertical = builder.verticalAlignment
+
+    // content padding is a pair of pairs,
+    // the first pair is the horizontal padding,
+    // the second pair is the vertical padding
+    private val contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = builder.contentPadding
+
+    private val reverseLayout: Boolean = builder.reverseLayout
+
+    @Composable
+    fun ComposeLazyItems(
+        items: MutableList<ComposableTreeNode>,
+        drawContent: @Composable (node: ComposableTreeNode) -> Unit
+    ) {
+        LazyRow(
+            modifier = modifier,
+            reverseLayout = reverseLayout,
+            horizontalArrangement = horizontalArrangement,
+            verticalAlignment = verticalAlignment,
+            contentPadding = PaddingValues(
+                contentPadding.first.first.dp,
+                contentPadding.second.first.dp,
+                contentPadding.first.second.dp,
+                contentPadding.second.second.dp
+            ),
+            content = {
+                items(items, key = { item -> item.id }) { item -> drawContent(item) }
+            }
+        )
+    }
+
+    class Builder : ComposableBuilder() {
+        var horizontalArrangement: Arrangement.Horizontal = Arrangement.SpaceAround
+        var verticalAlignment: Alignment.Vertical = Alignment.CenterVertically
+        var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = Pair(Pair(0, 0), Pair(0, 0))
+        var reverseLayout: Boolean = false
+
+        fun reverseLayout(isReverseLayout: String) = apply {
+            if (isReverseLayout.isNotEmpty()) {
+                this.reverseLayout = isReverseLayout.toBoolean()
+            }
+        }
+
+        fun horizontalArrangement(horizontalArrangement: String) = apply {
+            if (horizontalArrangement.isNotEmpty()) {
+                this.horizontalArrangement = when (horizontalArrangement) {
+                    "spaced-evenly" -> Arrangement.SpaceEvenly
+                    "space-around" -> Arrangement.SpaceAround
+                    "space-between" -> Arrangement.SpaceBetween
+                    "start" -> Arrangement.Start
+                    "end" -> Arrangement.End
+                    else -> if (horizontalArrangement.isNotEmptyAndIsDigitsOnly()) {
+                        Arrangement.spacedBy(horizontalArrangement.toInt().dp)
+                    } else {
+                        Arrangement.Center
+                    }
+                }
+            }
+        }
+
+        fun verticalAlignment(verticalAlignment: String) = apply {
+            if (verticalAlignment.isNotEmpty()) {
+                this.verticalAlignment = when (verticalAlignment) {
+                    "top" -> Alignment.Top
+                    "center" -> Alignment.CenterVertically
+                    else -> Alignment.Bottom
+                }
+            }
+        }
+
+        fun rightPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding = Pair(
+                    Pair(contentPadding.first.first, paddingValue.toInt()),
+                    Pair(contentPadding.second.first, contentPadding.second.second)
+                )
+            }
+        }
+
+        fun leftPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding = Pair(
+                    Pair(paddingValue.toInt(), contentPadding.first.second),
+                    Pair(contentPadding.second.first, contentPadding.second.second)
+                )
+            }
+        }
+
+        fun topPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding = Pair(
+                    Pair(contentPadding.first.first, contentPadding.first.second),
+                    Pair(paddingValue.toInt(), contentPadding.second.second)
+                )
+            }
+        }
+
+        fun bottomPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding = Pair(
+                    Pair(contentPadding.first.first, contentPadding.first.second),
+                    Pair(contentPadding.second.first, paddingValue.toInt())
+                )
+            }
+        }
+
+        fun lazyRowItemPadding(paddingValue: String) = apply {
+            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
+                contentPadding = Pair(
+                    Pair(paddingValue.toInt(), paddingValue.toInt()),
+                    Pair(paddingValue.toInt(), paddingValue.toInt())
+                )
+            }
+        }
+
+        override fun size(size: String): Builder = apply { super.size(size) }
+
+        override fun padding(padding: String): Builder = apply { super.padding(padding) }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply { super.height(height) }
+
+        override fun width(width: String): Builder = apply { super.width(width) }
+
+        fun build() = LazyRowDTO(this)
+    }
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
@@ -5,6 +5,7 @@ object ComposableTypes {
     const val card = "card"
     const val column = "column"
     const val lazyColumn = "lazy-column"
+    const val lazyRow = "lazy-row"
     const val row = "row"
     const val text = "text"
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -128,7 +128,7 @@ object ComposableNodeFactory {
                     "item-top-padding" -> builder.topPadding(attribute.value)
                     "item-vertical-padding" -> builder.verticalPadding(attribute.value)
                     "padding" -> builder.padding(attribute.value)
-                    "reverse-layout" -> builder.horizontalAlignment(attribute.value)
+                    "reverse-layout" -> builder.reverseLayout(attribute.value)
                     "size" -> builder.size(attribute.value)
                     "vertical-arrangement" -> builder.verticalArrangement(attribute.value)
                     "vertical-padding" -> builder.verticalPadding(attribute.value)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -25,6 +25,9 @@ object ComposableNodeFactory {
         ComposableTypes.lazyColumn -> ComposableTreeNode(
             buildLazyColumnNode(attributes = element.attributes())
         )
+        ComposableTypes.lazyRow -> ComposableTreeNode(
+            buildLazyRowNode(attributes = element.attributes())
+        )
         ComposableTypes.row -> ComposableTreeNode(buildRowNode(element.attributes()))
         ComposableTypes.text -> ComposableTreeNode(
             buildTextNode(attributes = element.attributes(), text = element.text())
@@ -131,6 +134,31 @@ object ComposableNodeFactory {
                     "reverse-layout" -> builder.reverseLayout(attribute.value)
                     "size" -> builder.size(attribute.value)
                     "vertical-arrangement" -> builder.verticalArrangement(attribute.value)
+                    "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    "width" -> builder.width(attribute.value)
+                    else -> builder
+                }
+            }
+            .build()
+
+    private fun buildLazyRowNode(attributes: Attributes): ComposableView =
+        attributes
+            .fold(LazyRowDTO.Builder()) { builder, attribute ->
+                when (attribute.key) {
+                    "height" -> builder.height(attribute.value)
+                    "horizontal-arrangement" -> builder.horizontalArrangement(horizontalArrangement = attribute.value)
+                    "horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "item-bottom-padding" -> builder.bottomPadding(attribute.value)
+                    "item-horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "item-left-padding" -> builder.leftPadding(attribute.value)
+                    "item-padding" -> builder.lazyRowItemPadding(attribute.value)
+                    "item-right-padding" -> builder.rightPadding(attribute.value)
+                    "item-top-padding" -> builder.topPadding(attribute.value)
+                    "item-vertical-padding" -> builder.verticalPadding(attribute.value)
+                    "padding" -> builder.padding(attribute.value)
+                    "reverse-layout" -> builder.reverseLayout(attribute.value)
+                    "size" -> builder.size(attribute.value)
+                    "vertical-alignment" -> builder.verticalAlignment(verticalAlignment = attribute.value)
                     "vertical-padding" -> builder.verticalPadding(attribute.value)
                     "width" -> builder.width(attribute.value)
                     else -> builder

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -27,6 +27,11 @@ private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
             composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
                 TraverseComposableViewTree(composableTreeNode = node)
             }
+        is LazyRowDTO ->{
+            composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node->
+                TraverseComposableViewTree(composableTreeNode = node)
+            }
+        }
         is RowDTO -> composableTreeNode.value.Compose {
             composableTreeNode.children.forEach { node ->
                 TraverseComposableViewTree(composableTreeNode = node)


### PR DESCRIPTION
Closes #15 

This adds support for lazy row. Lazy column is an extension of row and loads element in a horizontal fashion, however, unlike row it can lazy load items and reuse previously rendered views.

each element can be segregated using the item tag

```html

<item> <text> Hello Live View </text> </item>

```
Template

```html

   <lazy-row horizontal-arrangement= "16" vertical-alignment="center" height="fill" width = "fill" item-padding = "16">
      <item>
         <card elevation="2" shape="8" width="200" height ="350" background-color = "0xFFF2F2F2" >
            <column vertical-arrangement="space-evenly" horizontal-alignment="start" size="fill" padding = "12" >
               <async-image width="fill" height="150" content-scale="fit" shape="18"> https://m.media-amazon.com/images/M/MV5BZDY0Mjg1OTEtMDEyNS00OWM0LTg0YTYtNjA3YzY2NGRjYWJiXkEyXkFqcGdeQXVyODk4OTc3MTY@._V1_FMjpg_UX1000_.jpg </async-image>
               <text color="0xFF000000" font-size="24" font-weight="W800"> Ant Man and The Wasp: Quantamania </text>
               <text color="0xFF000000" font-size="14" max-lines="4" overflow="ellipsis">Ant-Man and the Wasp find themselves exploring the Quantum Realm, interacting with strange new creatures and embarking on an adventure that pushes them beyond the limits of what they thought was possible.</text>
               <row horizontal-arrangement="space-between" vertical-alignment="center">
                  <text color="0xFFF4B400" font-size="12"> Audience rating 94%</text>
                  <text color="0xFFF4B400" font-size="12"> Roton tomatoes rating 64%</text>
               </row>
            </column>
         </card>
      </item>
   </lazy-row>

```

[lazyRow.webm](https://user-images.githubusercontent.com/61690178/215757307-52f5fc0e-0129-459c-9320-d9b73695096b.webm)

Attribute list:

"item-left-padding"
"item-right-padding"
"item-top-padding"
"item-bottom-padding"
"item-horizontal-padding"
"item-vertical-padding"
"item-padding"
"padding"
"reverse-layout"
"horizontal-arrangement"
"height"
"width"
"vertical-alignment"
"size"
"horizontal-padding"
"vertical-padding"

Documentation Link:
https://developer.android.com/jetpack/compose/lists

