### PR TITLE
Feature spacer

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/SpacerDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/SpacerDTO.kt
@@ -1,0 +1,42 @@
+package org.phoenixframework.liveview.data.dto
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.runtime.Composable
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+
+class SpacerDTO private constructor(builder: Builder) :
+    ComposableView(modifier = builder.modifier) {
+    @Composable
+    fun Compose() {
+        Spacer(modifier = modifier)
+    }
+
+    class Builder : ComposableBuilder() {
+        override fun size(size: String): Builder = apply {
+            super.size(size)
+        }
+
+        override fun padding(padding: String): Builder = apply {
+            super.padding(padding)
+        }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply {
+            super.height(height)
+        }
+
+        override fun width(width: String): Builder = apply {
+            super.width(width)
+        }
+
+        fun build() = SpacerDTO(this)
+    }
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
@@ -7,5 +7,6 @@ object ComposableTypes {
     const val lazyColumn = "lazy-column"
     const val lazyRow = "lazy-row"
     const val row = "row"
+    const val spacer = "spacer"
     const val text = "text"
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -29,6 +29,7 @@ object ComposableNodeFactory {
             buildLazyRowNode(attributes = element.attributes())
         )
         ComposableTypes.row -> ComposableTreeNode(buildRowNode(element.attributes()))
+        ComposableTypes.spacer -> ComposableTreeNode(buildSpacerNode(element.attributes()))
         ComposableTypes.text -> ComposableTreeNode(
             buildTextNode(attributes = element.attributes(), text = element.text())
         )
@@ -188,6 +189,21 @@ object ComposableNodeFactory {
                     "padding" -> builder.padding(attribute.value)
                     "horizontal-padding" -> builder.horizontalPadding(attribute.value)
                     "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    else -> builder
+                }
+            }
+            .build()
+
+    private fun buildSpacerNode(attributes: Attributes): ComposableView =
+        attributes
+            .fold(SpacerDTO.Builder()) { builder, attribute ->
+                when (attribute.key) {
+                    "size" -> builder.size(attribute.value)
+                    "padding" -> builder.padding(attribute.value)
+                    "horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    "height" -> builder.height(attribute.value)
+                    "width" -> builder.width(attribute.value)
                     else -> builder
                 }
             }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -27,8 +27,8 @@ private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
             composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
                 TraverseComposableViewTree(composableTreeNode = node)
             }
-        is LazyRowDTO ->{
-            composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node->
+        is LazyRowDTO -> {
+            composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
                 TraverseComposableViewTree(composableTreeNode = node)
             }
         }
@@ -37,6 +37,7 @@ private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
                 TraverseComposableViewTree(composableTreeNode = node)
             }
         }
+        is SpacerDTO -> composableTreeNode.value.Compose()
         is TextDTO -> composableTreeNode.value.Compose()
     }
 }


### PR DESCRIPTION
Closes #11 

Adds support for Spacer. 

```html
<spacer height= "18" />

```

without spacer 
![Screenshot 2023-01-31 at 6 51 35 PM](https://user-images.githubusercontent.com/61690178/215778563-ad2665c0-354c-4b2c-b7ee-c5c1b85cb273.png)

with spacer 
![Screenshot 2023-01-31 at 6 52 14 PM](https://user-images.githubusercontent.com/61690178/215778752-534ac4fa-cfe1-474d-befb-ac6a20ee3684.png)

attribute list:
 "size" 
 "height" 
 "width" 
 "padding"
 "horizontal-padding" 
"vertical-padding"
Documentation Link:
https://developer.android.com/jetpack/compose/modifiers#:~:text=you%20want%20a-,child,-layout%20to%20be