### PR TITLE
Feature scaffold and  topbar

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/AsyncImageDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/AsyncImageDTO.kt
@@ -1,5 +1,6 @@
 package org.phoenixframework.liveview.data.dto
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -14,6 +15,7 @@ import coil.request.ImageRequest
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class AsyncImageDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
@@ -24,14 +26,16 @@ class AsyncImageDTO private constructor(builder: Builder) :
     private val contentScale: ContentScale = builder.contentScale
 
     @Composable
-    fun Compose() {
+    fun Compose(paddingValues: PaddingValues?) {
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
                 .data(imageUrl)
                 .crossfade(crossFade).build(),
             contentDescription = contentDescription,
             contentScale = contentScale,
-            modifier = modifier.clip(shape)
+            modifier = modifier
+                .clip(shape)
+                .paddingIfNotNull(paddingValues)
         )
     }
 

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
@@ -1,5 +1,6 @@
 package org.phoenixframework.liveview.data.dto
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
@@ -12,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class CardDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
     var shape: Shape = builder.shape
@@ -19,9 +21,9 @@ class CardDTO private constructor(builder: Builder) : ComposableView(modifier = 
     var elevation: Dp = builder.elevation
 
     @Composable
-    fun Compose(content: @Composable () -> Unit) {
+    fun Compose(paddingValues: PaddingValues?, content: @Composable () -> Unit) {
         Card(
-            modifier = modifier,
+            modifier = modifier.paddingIfNotNull(paddingValues),
             backgroundColor = backgroundColor,
             elevation = elevation,
             shape = shape,

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ColumnDTO.kt
@@ -2,10 +2,12 @@ package org.phoenixframework.liveview.data.dto
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class ColumnDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
@@ -13,9 +15,9 @@ class ColumnDTO private constructor(builder: Builder) :
     var horizontalAlignment: Alignment.Horizontal = builder.horizontalAlignment
 
     @Composable
-    fun Compose(content: @Composable () -> Unit) {
+    fun Compose(paddingValues: PaddingValues?, content: @Composable () -> Unit) {
         Column(
-            modifier = modifier,
+            modifier = modifier.paddingIfNotNull(paddingValues),
             verticalArrangement = verticalArrangement,
             horizontalAlignment = horizontalAlignment
         ) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
@@ -1,6 +1,7 @@
 package org.phoenixframework.liveview.data.dto
 
 import android.util.Log
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.runtime.Composable
@@ -9,6 +10,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.toColor
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class IconDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
     var contentDescription: String = builder.contentDescription
@@ -16,9 +18,14 @@ class IconDTO private constructor(builder: Builder) : ComposableView(modifier = 
     var imageVector: ImageVector? = builder.imageVector
 
     @Composable
-    fun Compose() {
+    fun Compose(paddingValues: PaddingValues?) {
         imageVector?.let { imageVector ->
-            Icon(imageVector = imageVector, contentDescription = contentDescription, tint = tint)
+            Icon(
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                tint = tint,
+                modifier = modifier.paddingIfNotNull(paddingValues)
+            )
         }
     }
 

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.domain.extensions.toColor
 
 class IconDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
     var contentDescription: String = builder.contentDescription
@@ -65,8 +66,6 @@ class IconDTO private constructor(builder: Builder) : ComposableView(modifier = 
         fun build() = IconDTO(this)
     }
 }
-
-private fun String.toColor(): Color = Color(this.toLong())
 
 private fun String.toMaterialIcon(): ImageVector? = try {
     val imageParameters = split(":")

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
@@ -11,6 +11,7 @@ import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class LazyColumnDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
@@ -27,10 +28,11 @@ class LazyColumnDTO private constructor(builder: Builder) :
     @Composable
     fun ComposeLazyItems(
         items: MutableList<ComposableTreeNode>,
+        paddingValues: PaddingValues?,
         drawContent: @Composable (node: ComposableTreeNode) -> Unit
     ) {
         LazyColumn(
-            modifier = modifier,
+            modifier = modifier.paddingIfNotNull(paddingValues),
             reverseLayout = reverseLayout,
             verticalArrangement = verticalArrangement,
             horizontalAlignment = horizontalAlignment,

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
@@ -11,6 +11,7 @@ import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class LazyRowDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
@@ -27,10 +28,11 @@ class LazyRowDTO private constructor(builder: Builder) :
     @Composable
     fun ComposeLazyItems(
         items: MutableList<ComposableTreeNode>,
+        paddingValues: PaddingValues?,
         drawContent: @Composable (node: ComposableTreeNode) -> Unit
     ) {
         LazyRow(
-            modifier = modifier,
+            modifier = modifier.paddingIfNotNull(paddingValues),
             reverseLayout = reverseLayout,
             horizontalArrangement = horizontalArrangement,
             verticalAlignment = verticalAlignment,

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/RowDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/RowDTO.kt
@@ -1,20 +1,22 @@
 package org.phoenixframework.liveview.data.dto
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class RowDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
     var horizontalArrangement: Arrangement.Horizontal = builder.horizontalArrangement
     var verticalAlignment: Alignment.Vertical = builder.verticalAlignment
 
     @Composable
-    fun Compose(content: @Composable () -> Unit) {
+    fun Compose(paddingValues: PaddingValues?, content: @Composable () -> Unit) {
         Row(
-            modifier = modifier,
+            modifier = modifier.paddingIfNotNull(paddingValues),
             horizontalArrangement = horizontalArrangement,
             verticalAlignment = verticalAlignment
         ) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ScaffoldDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ScaffoldDTO.kt
@@ -1,11 +1,13 @@
 package org.phoenixframework.liveview.data.dto
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.toColor
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class ScaffoldDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
@@ -14,12 +16,14 @@ class ScaffoldDTO private constructor(builder: Builder) :
     private val backgroundColor: Color = builder.backgroundColor
 
     @Composable
-    fun Compose(content: @Composable () -> Unit) {
-        Scaffold(modifier = modifier, backgroundColor = backgroundColor, topBar = {
-            topAppBar?.Compose()
-        }) { paddingValues ->
-            paddingValues
-            content()
+    fun Compose(paddingValues: PaddingValues?, content: @Composable (PaddingValues) -> Unit) {
+        Scaffold(
+            modifier = modifier.paddingIfNotNull(paddingValues),
+            backgroundColor = backgroundColor,
+            topBar = {
+                topAppBar?.Compose()
+            }) { contentPaddingValues ->
+            content(contentPaddingValues)
         }
     }
 

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ScaffoldDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ScaffoldDTO.kt
@@ -1,0 +1,62 @@
+package org.phoenixframework.liveview.data.dto
+
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.domain.extensions.toColor
+
+class ScaffoldDTO private constructor(builder: Builder) :
+    ComposableView(modifier = builder.modifier) {
+    // set by LiveViewCoordinator.extractChildren
+    var topAppBar: TopAppBarDTO? = null
+    private val backgroundColor: Color = builder.backgroundColor
+
+    @Composable
+    fun Compose(content: @Composable () -> Unit) {
+        Scaffold(modifier = modifier, backgroundColor = backgroundColor, topBar = {
+            topAppBar?.Compose()
+        }) { paddingValues ->
+            paddingValues
+            content()
+        }
+    }
+
+    class Builder : ComposableBuilder() {
+        var backgroundColor: Color = Color.White
+
+        fun backgroundColor(color: String) = apply {
+            if (color.isNotEmpty()) {
+                this.backgroundColor = color.toColor()
+            }
+        }
+
+        override fun size(size: String): Builder = apply {
+            super.size(size)
+        }
+
+        override fun padding(padding: String): Builder = apply {
+            super.padding(padding)
+        }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply {
+            super.height(height)
+        }
+
+        override fun width(width: String): Builder = apply {
+            super.width(width)
+        }
+
+        fun build() = ScaffoldDTO(this)
+    }
+}
+

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/SpacerDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/SpacerDTO.kt
@@ -1,15 +1,17 @@
 package org.phoenixframework.liveview.data.dto
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class SpacerDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
     @Composable
-    fun Compose() {
-        Spacer(modifier = modifier)
+    fun Compose(paddingValues: PaddingValues?) {
+        Spacer(modifier = modifier.paddingIfNotNull(paddingValues))
     }
 
     class Builder : ComposableBuilder() {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TextDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TextDTO.kt
@@ -1,5 +1,6 @@
 package org.phoenixframework.liveview.data.dto
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -14,6 +15,7 @@ import androidx.compose.ui.unit.sp
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
+import org.phoenixframework.liveview.ui.phx_components.paddingIfNotNull
 
 class TextDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
     var text: String = builder.text
@@ -31,11 +33,11 @@ class TextDTO private constructor(builder: Builder) : ComposableView(modifier = 
     var maxLines: Int = builder.maxLines
 
     @Composable
-    fun Compose() {
+    fun Compose(paddingValues: PaddingValues?) {
         Text(
             text = text,
             color = color,
-            modifier = modifier,
+            modifier = modifier.paddingIfNotNull(paddingValues),
             fontSize = fontSize,
             fontStyle = fontStyle,
             fontWeight = fontWeight,

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
@@ -36,12 +36,12 @@ class TopAppBarDTO private constructor(builder: Builder) :
         TopAppBar(
             backgroundColor = Color.White,
             title = {
-                textDTO?.Compose()
+                textDTO?.Compose(paddingValues = null)
             },
             navigationIcon = navigationIcon,
             actions = {
                 actionIcons.forEach { actionIcon ->
-                    actionIcon.Compose()
+                    actionIcon.Compose(paddingValues = null)
 
                 }
             },
@@ -53,7 +53,7 @@ class TopAppBarDTO private constructor(builder: Builder) :
         val navIcons = mutableListOf<IconDTO>()
         val actionIcons = mutableListOf<IconDTO>()
         var backgroundColor = Color.White
-         var textDTO: TextDTO? = null
+        var textDTO: TextDTO? = null
 
         fun backgroundColor(color: String) = apply {
             if (color.isNotEmpty()) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
@@ -1,0 +1,99 @@
+package org.phoenixframework.liveview.data.dto
+
+import androidx.compose.material.Icon
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+import org.phoenixframework.liveview.domain.extensions.toColor
+
+class TopAppBarDTO private constructor(builder: Builder) :
+    ComposableView(modifier = builder.modifier) {
+    private val actionIcons: List<IconDTO> = builder.actionIcons
+    private val navIcons: List<IconDTO> = builder.navIcons
+    private val textDTO: TextDTO? = builder.textDTO
+
+    @Composable
+    fun Compose() {
+        val navigationIcon: @Composable (() -> Unit)? =
+            navIcons
+                .takeUnless(List<IconDTO>::isEmpty)
+                ?.let {
+                    {
+                        it.forEach { icon ->
+                            icon.imageVector?.let { imageVector ->
+                                Icon(
+                                    imageVector = imageVector,
+                                    contentDescription = icon.contentDescription,
+                                    tint = icon.tint
+                                )
+                            }
+                        }
+                    }
+                }
+
+        TopAppBar(
+            backgroundColor = Color.White,
+            title = {
+                textDTO?.Compose()
+            },
+            navigationIcon = navigationIcon,
+            actions = {
+                actionIcons.forEach { actionIcon ->
+                    actionIcon.Compose()
+
+                }
+            },
+            modifier = modifier
+        )
+    }
+
+    class Builder : ComposableBuilder() {
+        val navIcons = mutableListOf<IconDTO>()
+        val actionIcons = mutableListOf<IconDTO>()
+        var backgroundColor = Color.White
+         var textDTO: TextDTO? = null
+
+        fun backgroundColor(color: String) = apply {
+            if (color.isNotEmpty()) {
+                backgroundColor = color.toColor()
+            }
+        }
+
+        fun addNavIcon(navIcon: IconDTO) = apply {
+            navIcons.add(navIcon)
+        }
+
+        fun addActionIcon(actionIcon: IconDTO) = apply {
+            actionIcons.add(actionIcon)
+        }
+
+        override fun size(size: String): Builder = apply {
+            super.size(size)
+        }
+
+        override fun padding(padding: String): Builder = apply {
+            super.padding(padding)
+        }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply {
+            super.height(height)
+        }
+
+        override fun width(width: String): Builder = apply {
+            super.width(width)
+        }
+
+        fun build() = TopAppBarDTO(this)
+    }
+}
+

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
@@ -91,7 +91,7 @@ class LiveViewCoordinator(url: String) : ViewModel() {
         elements.forEach { element ->
             Log.e("VM", "=====================> \n element: $element")
 
-            val viewTree = createComposable(element)
+            val viewTree = createComposableTreeNode(element)
 
             extractChildren(viewTree, element.children())
 
@@ -114,7 +114,7 @@ class LiveViewCoordinator(url: String) : ViewModel() {
     private fun extractChildren(parent: ComposableTreeNode, children: Elements) {
         for (child in children) {
             // Create a tree node for the child element
-            val childNode = createComposable(child)
+            val childNode = createComposableTreeNode(child)
 
             // Add the child node to the parent node
             if (childNode.value is TopAppBarDTO && parent.value is ScaffoldDTO) {
@@ -127,6 +127,6 @@ class LiveViewCoordinator(url: String) : ViewModel() {
         }
     }
 
-    private fun createComposable(element: Element): ComposableTreeNode =
-        ComposableNodeFactory.buildComposable(element)
+    private fun createComposableTreeNode(element: Element): ComposableTreeNode =
+        ComposableNodeFactory.buildComposableTreeNode(element)
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.launch
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
+import org.phoenixframework.liveview.data.dto.ScaffoldDTO
+import org.phoenixframework.liveview.data.dto.TopAppBarDTO
 import org.phoenixframework.liveview.data.repository.Repository
 import org.phoenixframework.liveview.domain.factory.ComposableNodeFactory
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
@@ -115,8 +117,11 @@ class LiveViewCoordinator(url: String) : ViewModel() {
             val childNode = createComposable(child)
 
             // Add the child node to the parent node
-            parent.addNode(childNode)
-
+            if (childNode.value is TopAppBarDTO && parent.value is ScaffoldDTO) {
+                parent.value.topAppBar = childNode.value
+            } else {
+                parent.addNode(childNode)
+            }
             // Recursively add the child's child nodes to the tree
             extractChildren(childNode, child.children())
         }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
@@ -8,6 +8,8 @@ object ComposableTypes {
     const val lazyColumn = "lazy-column"
     const val lazyRow = "lazy-row"
     const val row = "row"
+    const val scaffold = "scaffold"
     const val spacer = "spacer"
     const val text = "text"
+    const val topAppBar = "top-app-bar"
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/extensions/Extensions.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/extensions/Extensions.kt
@@ -1,5 +1,7 @@
 package org.phoenixframework.liveview.domain.extensions
 
+import androidx.compose.ui.graphics.Color
 import androidx.core.text.isDigitsOnly
 
 fun String.isNotEmptyAndIsDigitsOnly(): Boolean = this.isNotEmpty() && this.isDigitsOnly()
+fun String.toColor(): Color = Color(this.toLong())

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -23,16 +23,16 @@ object ComposableNodeFactory {
         ComposableTypes.card -> ComposableTreeNode(buildCardNode(element.attributes()))
         ComposableTypes.column -> ComposableTreeNode(buildColumnNode(element.attributes()))
         ComposableTypes.icon -> ComposableTreeNode(buildIconNode(element.attributes()))
-        ComposableTypes.lazyColumn -> ComposableTreeNode(
-            buildLazyColumnNode(element.attributes())
-        )
-        ComposableTypes.lazyRow -> ComposableTreeNode(
-            buildLazyRowNode(element.attributes())
-        )
+        ComposableTypes.lazyColumn -> ComposableTreeNode(buildLazyColumnNode(element.attributes()))
+        ComposableTypes.lazyRow -> ComposableTreeNode(buildLazyRowNode(element.attributes()))
         ComposableTypes.row -> ComposableTreeNode(buildRowNode(element.attributes()))
+        ComposableTypes.scaffold -> ComposableTreeNode(buildScaffoldNode(element.attributes()))
         ComposableTypes.spacer -> ComposableTreeNode(buildSpacerNode(element.attributes()))
         ComposableTypes.text -> ComposableTreeNode(
             buildTextNode(attributes = element.attributes(), text = element.text())
+        )
+        ComposableTypes.topAppBar -> ComposableTreeNode(
+            buildTopAppBarNode(element = element, attributes = element.attributes())
         )
         else -> ComposableTreeNode(
             buildTextNode(
@@ -212,6 +212,22 @@ object ComposableNodeFactory {
             }
             .build()
 
+    private fun buildScaffoldNode(attributes: Attributes): ComposableView =
+        attributes
+            .fold(ScaffoldDTO.Builder()) { builder, attribute ->
+                when (attribute.key) {
+                    "background-color" -> builder.backgroundColor(attribute.value)
+                    "size" -> builder.size(attribute.value)
+                    "height" -> builder.height(attribute.value)
+                    "width" -> builder.width(attribute.value)
+                    "padding" -> builder.padding(attribute.value)
+                    "horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    else -> builder
+                }
+            }
+            .build()
+
     private fun buildSpacerNode(attributes: Attributes): ComposableView =
         attributes
             .fold(SpacerDTO.Builder()) { builder, attribute ->
@@ -260,4 +276,38 @@ object ComposableNodeFactory {
                 }
             }
             .build()
+
+    private fun buildTopAppBarNode(element: Element, attributes: Attributes): ComposableView =
+        attributes
+            .fold(TopAppBarDTO.Builder()) { builder, attribute ->
+                when (attribute.key) {
+                    "background-color" -> builder.backgroundColor(attribute.value)
+                    "size" -> builder.size(attribute.value)
+                    "height" -> builder.height(attribute.value)
+                    "width" -> builder.width(attribute.value)
+                    "padding" -> builder.padding(attribute.value)
+                    "horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    else -> builder
+                }
+            }
+            .also { builder ->
+                element.select("text").first()?.let { element ->
+                    builder.textDTO =
+                        buildTextNode(element.attributes(), element.text()) as TextDTO
+                }
+
+                element.select("nav-icon").forEach { navIcon ->
+                    buildAndAddIconNode(navIcon, builder::addNavIcon)
+                }
+
+                element.select("action-icon").forEach { actionIcon ->
+                    buildAndAddIconNode(actionIcon, builder::addActionIcon)
+                }
+            }
+            .build()
+
+    private fun buildAndAddIconNode(element: Element, setter: (IconDTO) -> Unit) {
+        setter(buildIconNode(element.attributes()))
+    }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -18,27 +18,31 @@ object ComposableNodeFactory {
      * @param element the `Element` object to create the `ComposableTreeNode` object from
      * @return a `ComposableTreeNode` object based on the input `Element` object
      */
-    fun buildComposable(element: Element): ComposableTreeNode = when (element.tagName()) {
-        ComposableTypes.asyncImage -> ComposableTreeNode(buildAsyncImageNode(element.attributes()))
-        ComposableTypes.card -> ComposableTreeNode(buildCardNode(element.attributes()))
-        ComposableTypes.column -> ComposableTreeNode(buildColumnNode(element.attributes()))
-        ComposableTypes.icon -> ComposableTreeNode(buildIconNode(element.attributes()))
-        ComposableTypes.lazyColumn -> ComposableTreeNode(buildLazyColumnNode(element.attributes()))
-        ComposableTypes.lazyRow -> ComposableTreeNode(buildLazyRowNode(element.attributes()))
-        ComposableTypes.row -> ComposableTreeNode(buildRowNode(element.attributes()))
-        ComposableTypes.scaffold -> ComposableTreeNode(buildScaffoldNode(element.attributes()))
-        ComposableTypes.spacer -> ComposableTreeNode(buildSpacerNode(element.attributes()))
-        ComposableTypes.text -> ComposableTreeNode(
-            buildTextNode(attributes = element.attributes(), text = element.text())
+    fun buildComposableTreeNode(element: Element): ComposableTreeNode =
+        buildComposableView(element)
+            .let(::ComposableTreeNode)
+
+    private fun buildComposableView(element: Element): ComposableView = when (element.tagName()) {
+        ComposableTypes.asyncImage -> buildAsyncImageNode(element.attributes())
+        ComposableTypes.card -> buildCardNode(element.attributes())
+        ComposableTypes.column -> buildColumnNode(element.attributes())
+        ComposableTypes.icon -> buildIconNode(element.attributes())
+        ComposableTypes.lazyColumn -> buildLazyColumnNode(element.attributes())
+        ComposableTypes.lazyRow -> buildLazyRowNode(element.attributes())
+        ComposableTypes.row -> buildRowNode(element.attributes())
+        ComposableTypes.scaffold -> buildScaffoldNode(element.attributes())
+        ComposableTypes.spacer -> buildSpacerNode(element.attributes())
+        ComposableTypes.text -> buildTextNode(
+            attributes = element.attributes(),
+            text = element.text()
         )
-        ComposableTypes.topAppBar -> ComposableTreeNode(
-            buildTopAppBarNode(element = element, attributes = element.attributes())
+        ComposableTypes.topAppBar -> buildTopAppBarNode(
+            element = element,
+            attributes = element.attributes()
         )
-        else -> ComposableTreeNode(
-            buildTextNode(
-                attributes = element.attributes(),
-                text = "${element.tagName()} not supported yet"
-            )
+        else -> buildTextNode(
+            attributes = element.attributes(),
+            text = "${element.tagName()} not supported yet"
         )
     }
 

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -28,12 +28,16 @@ private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
             composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
                 TraverseComposableViewTree(composableTreeNode = node)
             }
-        is LazyRowDTO -> {
+        is LazyRowDTO ->
             composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
                 TraverseComposableViewTree(composableTreeNode = node)
             }
-        }
         is RowDTO -> composableTreeNode.value.Compose {
+            composableTreeNode.children.forEach { node ->
+                TraverseComposableViewTree(composableTreeNode = node)
+            }
+        }
+        is ScaffoldDTO -> composableTreeNode.value.Compose {
             composableTreeNode.children.forEach { node ->
                 TraverseComposableViewTree(composableTreeNode = node)
             }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -1,48 +1,67 @@
 package org.phoenixframework.liveview.ui.phx_components
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import org.phoenixframework.liveview.data.dto.*
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 
 @Composable
 fun PhxLiveView(liveViewState: MutableList<ComposableTreeNode>) {
-    liveViewState.forEach { node -> TraverseComposableViewTree(composableTreeNode = node) }
+    liveViewState.forEach { node -> TraverseComposableViewTree(node, paddingValues = null) }
 }
 
 @Composable
-private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
+private fun TraverseComposableViewTree(
+    composableTreeNode: ComposableTreeNode,
+    paddingValues: PaddingValues?
+) {
     when (composableTreeNode.value) {
-        is AsyncImageDTO -> composableTreeNode.value.Compose()
-        is CardDTO -> composableTreeNode.value.Compose {
+        is AsyncImageDTO -> composableTreeNode.value.Compose(paddingValues)
+        is CardDTO -> composableTreeNode.value.Compose(paddingValues) {
             composableTreeNode.children.forEach { node ->
-                TraverseComposableViewTree(composableTreeNode = node)
+                TraverseComposableViewTree(node, paddingValues = null)
             }
         }
-        is ColumnDTO -> composableTreeNode.value.Compose {
+        is ColumnDTO -> composableTreeNode.value.Compose(paddingValues) {
             composableTreeNode.children.forEach { node ->
-                TraverseComposableViewTree(composableTreeNode = node)
+                TraverseComposableViewTree(node, paddingValues = null)
             }
         }
-        is IconDTO -> composableTreeNode.value.Compose()
+        is IconDTO -> composableTreeNode.value.Compose(paddingValues)
         is LazyColumnDTO ->
-            composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
-                TraverseComposableViewTree(composableTreeNode = node)
+            composableTreeNode.value.ComposeLazyItems(
+                composableTreeNode.children,
+                paddingValues
+            ) { node ->
+                TraverseComposableViewTree(node, paddingValues = null)
             }
         is LazyRowDTO ->
-            composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
-                TraverseComposableViewTree(composableTreeNode = node)
+            composableTreeNode.value.ComposeLazyItems(
+                composableTreeNode.children,
+                paddingValues
+            ) { node ->
+                TraverseComposableViewTree(node, paddingValues = null)
             }
-        is RowDTO -> composableTreeNode.value.Compose {
+        is RowDTO -> composableTreeNode.value.Compose(paddingValues) {
             composableTreeNode.children.forEach { node ->
-                TraverseComposableViewTree(composableTreeNode = node)
+                TraverseComposableViewTree(node, paddingValues = null)
             }
         }
-        is ScaffoldDTO -> composableTreeNode.value.Compose {
+        is ScaffoldDTO -> composableTreeNode.value.Compose(paddingValues) { contentPaddingValues ->
             composableTreeNode.children.forEach { node ->
-                TraverseComposableViewTree(composableTreeNode = node)
+                TraverseComposableViewTree(node, contentPaddingValues)
             }
         }
-        is SpacerDTO -> composableTreeNode.value.Compose()
-        is TextDTO -> composableTreeNode.value.Compose()
+        is SpacerDTO -> composableTreeNode.value.Compose(paddingValues)
+        is TextDTO -> composableTreeNode.value.Compose(paddingValues)
     }
 }
+
+fun Modifier.paddingIfNotNull(paddingValues: PaddingValues?): Modifier =
+    if (paddingValues != null) {
+        this.padding(paddingValues)
+    } else {
+        this
+    }


### PR DESCRIPTION
Closes #33 and #40 

Adds support for scaffold container layout and top with navigation and action icons.

```html
    <scaffold background-color="0xFFF2F2F2">
      <top-app-bar>
      <text color="0xFF000000" font-size="16" font-weight="W600">Home</text>
      <action-icon content-description="back button" >outlined:Create</action-icon>

        <action-icon content-description="back button" >outlined:Notifications</action-icon>
      </top-app-bar>
     </scaffold>

```
![Screenshot 2023-01-31 at 7 13 09 PM](https://user-images.githubusercontent.com/61690178/215783875-d77e8ff0-ac06-4256-a0d6-cd65ef20b35b.png)

icon uses key value pair to render the material icon icon_type:icon_name

icon type can be default, outlined, filled, sharp, two tone etc
icon name is the name of the icon.

Scaffold link: https://developer.android.com/jetpack/compose/layouts/material#scaffold
App bar link: https://developer.android.com/jetpack/compose/layouts/material#app-bars