### PR TITLE
Feature icon

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
@@ -1,0 +1,94 @@
+package org.phoenixframework.liveview.data.dto
+
+import android.util.Log
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.phoenixframework.liveview.domain.base.ComposableBuilder
+import org.phoenixframework.liveview.domain.base.ComposableView
+
+class IconDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
+    var contentDescription: String = builder.contentDescription
+    var tint: Color = builder.tint
+    var imageVector: ImageVector? = builder.imageVector
+
+    @Composable
+    fun Compose() {
+        imageVector?.let { imageVector ->
+            Icon(imageVector = imageVector, contentDescription = contentDescription, tint = tint)
+        }
+    }
+
+    class Builder : ComposableBuilder() {
+        var contentDescription: String = ""
+        var tint: Color = Color.Black
+        var imageVector: ImageVector? = null
+
+        fun contentDescription(contentDescription: String) = apply {
+            this.contentDescription = contentDescription
+        }
+
+        fun tint(tintColor: String) = apply {
+            this.tint = tintColor.toColor()
+        }
+
+        fun imageVector(image: String) = apply {
+            imageVector = image.toMaterialIcon()
+        }
+
+        override fun size(size: String): Builder = apply {
+            super.size(size)
+        }
+
+        override fun padding(padding: String): Builder = apply {
+            super.padding(padding)
+        }
+
+        override fun verticalPadding(padding: String): Builder = apply {
+            super.verticalPadding(padding)
+        }
+
+        override fun horizontalPadding(padding: String): Builder = apply {
+            super.horizontalPadding(padding)
+        }
+
+        override fun height(height: String): Builder = apply {
+            super.height(height)
+        }
+
+        override fun width(width: String): Builder = apply {
+            super.width(width)
+        }
+
+        fun build() = IconDTO(this)
+    }
+}
+
+private fun String.toColor(): Color = Color(this.toLong())
+
+private fun String.toMaterialIcon(): ImageVector? = try {
+    val imageParameters = split(":")
+    val themePackage = imageParameters.first()
+    val action = imageParameters.last()
+
+    val iconClass =
+        Class.forName("androidx.compose.material.icons.${themePackage}.${action}Kt")
+    val method = iconClass.declaredMethods.first()
+
+    val theme: Any = when (themePackage) {
+        "filled" -> Icons.Filled
+        "rounded" -> Icons.Rounded
+        "outlined" -> Icons.Outlined
+        "sharp" -> Icons.Sharp
+        "twotone" -> Icons.TwoTone
+        else -> Icons.Default
+    }
+
+    method.invoke(null, theme) as ImageVector
+} catch (e: Throwable) {
+    Log.e("NavIcon", e.message ?: "Icon not found")
+
+    null
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableTypes.kt
@@ -4,6 +4,7 @@ object ComposableTypes {
     const val asyncImage = "async-image"
     const val card = "card"
     const val column = "column"
+    const val icon = "icon"
     const val lazyColumn = "lazy-column"
     const val lazyRow = "lazy-row"
     const val row = "row"

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -22,11 +22,12 @@ object ComposableNodeFactory {
         ComposableTypes.asyncImage -> ComposableTreeNode(buildAsyncImageNode(element.attributes()))
         ComposableTypes.card -> ComposableTreeNode(buildCardNode(element.attributes()))
         ComposableTypes.column -> ComposableTreeNode(buildColumnNode(element.attributes()))
+        ComposableTypes.icon -> ComposableTreeNode(buildIconNode(element.attributes()))
         ComposableTypes.lazyColumn -> ComposableTreeNode(
-            buildLazyColumnNode(attributes = element.attributes())
+            buildLazyColumnNode(element.attributes())
         )
         ComposableTypes.lazyRow -> ComposableTreeNode(
-            buildLazyRowNode(attributes = element.attributes())
+            buildLazyRowNode(element.attributes())
         )
         ComposableTypes.row -> ComposableTreeNode(buildRowNode(element.attributes()))
         ComposableTypes.spacer -> ComposableTreeNode(buildSpacerNode(element.attributes()))
@@ -109,6 +110,23 @@ object ComposableNodeFactory {
                     "size" -> builder.size(attribute.value)
                     "height" -> builder.height(attribute.value)
                     "width" -> builder.width(attribute.value)
+                    "padding" -> builder.padding(attribute.value)
+                    "horizontal-padding" -> builder.horizontalPadding(attribute.value)
+                    "vertical-padding" -> builder.verticalPadding(attribute.value)
+                    else -> builder
+                }
+            }
+            .build()
+
+    private fun buildIconNode(attributes: Attributes): IconDTO =
+        attributes
+            .fold(IconDTO.Builder().imageVector(attributes.get("name"))) { builder, attribute ->
+                when (attribute.key) {
+                    "tint" -> builder.tint(attribute.value)
+                    "size" -> builder.size(attribute.value)
+                    "height" -> builder.height(attribute.value)
+                    "width" -> builder.width(attribute.value)
+                    "content-description" -> builder.contentDescription(attribute.value)
                     "padding" -> builder.padding(attribute.value)
                     "horizontal-padding" -> builder.horizontalPadding(attribute.value)
                     "vertical-padding" -> builder.verticalPadding(attribute.value)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -23,6 +23,7 @@ private fun TraverseComposableViewTree(composableTreeNode: ComposableTreeNode) {
                 TraverseComposableViewTree(composableTreeNode = node)
             }
         }
+        is IconDTO -> composableTreeNode.value.Compose()
         is LazyColumnDTO ->
             composableTreeNode.value.ComposeLazyItems(composableTreeNode.children) { node ->
                 TraverseComposableViewTree(composableTreeNode = node)


### PR DESCRIPTION
closes #54

Adds support for icon

```html
  <row padding = "32">

         <icon name= "filled:Create" />
         <icon name= "outlined:Create" />
         <icon name= "rounded:Create" />
   </row>
```

icon uses key value pair to render the material icon icon_type:icon_name

icon type can be default, outlined, filled, sharp, two tone etc
icon name is the name of the icon.


![Screenshot 2023-01-31 at 7 30 40 PM](https://user-images.githubusercontent.com/61690178/215788233-d2106543-fd44-4d86-a145-7cabfd8e19da.png)

Material icon link : https://fonts.google.com/icons
